### PR TITLE
replace babel-plugin with babel cli (bump minor)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "mocha": "^2.3.4"
   },
   "scripts": {
-    "build": "babel-plugin build",
-    "push": "babel-plugin publish",
+    "build": "babel src --out-dir lib",
+    "prepublish": "npm run build",
     "test": "mocha --compilers js:babel-register"
   },
   "keywords": [


### PR DESCRIPTION
resolves #1 npm is installing package without `lib` directory:

![image](https://cloud.githubusercontent.com/assets/1539088/12214833/ba8179a4-b671-11e5-9a3d-7b800223e7fa.png)


 thank you sir, sorry to bug you :beetle: