### PR TITLE
Expected doesn't match the code output

### DIFF
--- a/test/fixtures/pure-class-expression/expected.js
+++ b/test/fixtures/pure-class-expression/expected.js
@@ -1,4 +1,4 @@
-module.exports = (function () {
+module.exports = function () {
   function Foo(props) {
     props.foo;
     return <div />;
@@ -8,4 +8,4 @@ module.exports = (function () {
     foo: React.PropTypes.string.isRequired
   };
   return Foo;
-})();
+}();


### PR DESCRIPTION
The actual compiled code will match the above syntax without parenthesis wrapping the function. The pure class expression test fails because of this. 

1 failing

  1) fixtures pure class expression:

      AssertionError: 'module.exports = function () {\n  function Foo(props) {\n    props.foo;\n    return <div />;\n  }\n\n  Foo.propTypes = {\n    f == 'module.exports = (function () {\n  function Foo(props) {\n    props.foo;\n    return <div />;\n  }\n\n Foo.propTypes = {\n
      + expected - actual

      -module.exports = function () {
      +module.exports = (function () {
         function Foo(props) {
           props.foo;
           return <div />;
         }
         Foo.propTypes = {
           foo: React.PropTypes.string.isRequired
         };
         return Foo;
      -}();
      +})();